### PR TITLE
Update config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,33 +1,23 @@
 import Config
 
 config :crawly,
-  fetcher: {Crawly.Fetchers.Splash,
-    [
-      base_url: "http://localhost:8050/render.html",
-      wait: 3
-    ]},
-  retry:
-    [
-      retry_codes: [400, 500],
-      max_retries: 5,
-      ignored_middlewares: [Crawly.Middlewares.UniqueRequest]
-    ],
-    closespider_timeout: 5,
-    concurrent_requests_per_domain: 20,
-    closespider_itemcount: 1000,
-    middlewares: [
-      Crawly.Middlewares.DomainFilter,
-      Crawly.Middlewares.UniqueRequest,
-      Crawly.Middlewares.UserAgent
-    ],
-    user_agents: [
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41"
-    ],
-    pipelines: [
-      {Crawly.Pipelines.Validate, fields: [:id, :title, :url, :price]},
-      {Crawly.Pipelines.DuplicatesFilter, item_id: :id},
-      {Crawly.Pipelines.JSONEncoder, []},
-      {Crawly.Pipelines.WriteToFile, extension: "jl", folder: "/tmp"}
-    ]
+  fetcher: {Crawly.Fetchers.Splash, [base_url: "http://localhost:8050/render.html"]},
+  closespider_timeout: 10,
+  concurrent_requests_per_domain: 8,
+  closespider_itemcount: 100,
+
+  middlewares: [
+    Crawly.Middlewares.DomainFilter,
+    Crawly.Middlewares.UniqueRequest,
+    {Crawly.Middlewares.UserAgent, user_agents: ["Crawly Bot", "Google"]}
+  ],
+  pipelines: [
+    # An item is expected to have all fields defined in the fields list
+    {Crawly.Pipelines.Validate, fields: [:url]},
+
+    # Use the following field as an item uniq identifier (pipeline) drops
+    # items with the same urls
+    {Crawly.Pipelines.DuplicatesFilter, item_id: :url},
+    Crawly.Pipelines.JSONEncoder,
+    {Crawly.Pipelines.WriteToFile, extension: "jl", folder: "/tmp"}
+  ]

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule WhoscoredSpider.MixProject do
     [
       app: :whoscored_spider,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
The old config was taken from the article, and only works for old versions of Crawly (0.8.0 when the article was created). The updated config is just taken from:

https://hexdocs.pm/crawly/readme.html#quickstart